### PR TITLE
Fix compilation error on newer ubuntu releases

### DIFF
--- a/src/sim/init_signals.cc
+++ b/src/sim/init_signals.cc
@@ -66,18 +66,19 @@
 using namespace std;
 
 // Use an separate stack for fatal signal handlers
-static uint8_t fatalSigStack[2 * SIGSTKSZ];
 
 static bool
 setupAltStack()
 {
+    const auto stack_size = 2 * SIGSTKSZ;
+    static uint8_t *fatal_sig_stack = new uint8_t[stack_size];
     stack_t stack;
 #if defined(__FreeBSD__) && (__FreeBSD_version < 1100097)
-    stack.ss_sp = (char *)fatalSigStack;
+    stack.ss_sp = (char *)fatal_sig_stack;
 #else
-    stack.ss_sp = fatalSigStack;
+    stack.ss_sp = fatal_sig_stack;
 #endif
-    stack.ss_size = sizeof(fatalSigStack);
+    stack.ss_size = stack_size;
     stack.ss_flags = 0;
 
     return sigaltstack(&stack, NULL) == 0;


### PR DESCRIPTION
The repo can not be compiled on Ubuntu 22.04 because in glibc >= 2.34, SIGSTKSZ is changed to a system call instead of a constant value. I cherry picked the commit from gem5 upstream to fix the issue. It now compiles on Ubuntu 20.04/22.04.

Not sure there is any other issue causing "Unfortunately the repo doesn't appear to run correctly when tested on Ubuntu 20.04", seems working fine now :)

Upstream commit messeage:

Since glibc >= 2.34, MINSIGSTKSZ and SIGSTKSZ are no longer constant on Linux. As a result, the definition
"fatalSigStack[2*SIGSTKSZ]" fails to be compiled.
Thus, we need to dynamically allocate it.

Change-Id: Ibccc367818483b9c94beda871d1d95367d1e8b04 Reviewed-on: https://gem5-review.googlesource.com/c/public/gem5/+/53183
Reviewed-by: Gabe Black <gabe.black@gmail.com>
Maintainer: Gabe Black <gabe.black@gmail.com>
Tested-by: kokoro <noreply+kokoro@google.com>
(cherry picked from commit 39d4cdcd6bf1966b21c0d598e529c011f551b6bb)