### PR TITLE
fix pending squash bug

### DIFF
--- a/src/cpu/o3/iew_impl.hh
+++ b/src/cpu/o3/iew_impl.hh
@@ -1390,7 +1390,19 @@ DefaultIEW<Impl>::executeInsts()
         // instruction first, so the branch resolution order will be correct.
         ThreadID tid = inst->threadNumber;
 
-        if (!fetchRedirect[tid] ||
+
+	if (inst->isControl() && inst->mispredicted() && inst->isArgsTainted() && !inst->isUnsquashable()) {
+	    // The instruction is a branch which was mispredicted but tainted.
+	    // In order to avoid this tainted mispredicted branch from hiding
+	    // a younger *untainted* branch misprediction (which would create
+	    // a secret-dependent squash signal), instead just directly mark
+	    // this instruction as having a pending squash. This is functionally
+	    // equivalent to sending all tainted branch mispredictions to the
+	    // commit stage.
+	    DPRINTF(IEW, "[tid:%i] [sn:%llu] Execute: Tainted branch misprediction detected.\n",
+		  tid, inst->seqNum);
+	    inst->hasPendingSquash(true);
+	} else if (!fetchRedirect[tid] ||
             !toCommit->squash[tid] ||
             toCommit->squashedSeqNum[tid] > inst->seqNum) {
 


### PR DESCRIPTION
The original implementation of delayed branch resolution created a secret-dependent squash signal in the case of a younger, untainted branch and an older, tainted branch resolving in the same cycle. Specifically, if both resolved to mispredicted, then the IEW stage would only notify the commit stage of the older misprediction (i.e., the tainted branch misprediction), but not the younger one. However, if the younger, untainted branch was mispredicted but the older, tainted branch was correctly predicted, then the IEW stage notifies the commit stage of the younger, untainted branch misprediction. This results a secret-dependent squash signal---if the tainted branch was correctly predicted, then the CPU will start squashing starting at the younger, untainted instruction; if the tainted branch was mispredicted, then the squash of both the untainted and tainted branches will be delayed until the older, tainted branch becomes nonspeculative.

This patch fixes this issue by unconditionally setting the squash signal for untainted, mispredicted branches, regardless of whether any older, tainted branches were mispredicted in the same cycle. Instead, any tainted branches that are mispredicted are simply marked as having a pending squash when they eventually become nonspeculative.