### PR TITLE
taint all registers at rename

### DIFF
--- a/src/cpu/o3/rename_impl.hh
+++ b/src/cpu/o3/rename_impl.hh
@@ -1177,8 +1177,13 @@ DefaultRename<Impl>::renameDestRegs(DynInstPtr &inst, ThreadID tid)
 
         ++renameRenamedOperands;
 
-        // [Rutvik, SPT] When an inst is renamed, its dest regs start out with a clean slate
-        cpu->setTaint(rename_result.first, false);
+	// [SPT]
+	// Initial tainting/untainting is actually performed next cycle when the instruction
+	// enters the ROB. However, there are some cases (e.g., due to a fault handled at
+	// commit) where an instruction may not enter the ROB but still get issued/executed.
+	// So, to be safe, conservatively mark the destination register as tainted to start.
+	// It will be properly tainted/untainted once it enters the ROB next cycle.
+        cpu->setTaint(rename_result.first, true);
     }
 }
 


### PR DESCRIPTION
This patch fixes a bug that occasionally causes the destination registers of transient instructions to be untainted when they should have been tainted.

The original code unconditionally untaints all destination registers at rename and then assigns the correct taint to them once they are inserted into the ROB. However, this allows transient instructions that never enter the ROB but are nevertheless still issued/executed to execute with improperly untainted outputs. This can occur when a fault ---e.g., a page fault or a syscall---is detected at the commit stage.

This patch fixes this behavior by simply marking all destination registers as tainted to start at rename. Then, once the instruction is inserted into the ROB, SPT's taint logic proprely untaints/taints destination register.